### PR TITLE
Fix sending more than 16 files

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (opt) {
 
         files.push(file);
 
-        cb(null, file);
+        cb();
     }
 
     function endStream(cb) {


### PR DESCRIPTION
Somehow the callback parameter for through2 prevented more than 16 files to be sent (the script silently stops and endStream never gets called)
Yes, seriously.
I don't know why either, but you can try it out, it doesn't seem to make sense, and it was a pain to find out.

Anyway, this "fix" shouldn't break anything since you were already using a separate array to store the files in anyway. For me everything seems to work, however if this breaks something, I'm sorry.

Also let me know if you can even reproduce the issue with more than 16 files. I'm on Arch Linux with the node 6.2.1.
